### PR TITLE
Remove unnecessary library calls

### DIFF
--- a/global.R
+++ b/global.R
@@ -4,8 +4,6 @@ library(shiny)
 library(ggplot2)
 library(dplyr)
 library(shinythemes)
-library("ggplot2")
-library("tadaatoolbox")
 
 # optisches
 theme_set(theme_tadaa(bg = "white"))


### PR DESCRIPTION
Also helps with shinyapps.io deployment because `tadaatoolbox` has so many dependencies